### PR TITLE
Improve management of docker images

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -9,6 +9,7 @@ pipeline:
       - /var/run/docker.sock:/var/run/docker.sock
     commands:
       - docker --config /secrets/ pull 1and1internet/template-library-tools
+      - docker --config /secrets/ pull 1and1internet/ubuntu-16-rspec
 
   build:
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -39,3 +39,14 @@ pipeline:
     commands:
      - python3 -u /scripts/images/publish.py
 
+  clean:
+    when:
+      event: push
+      status: [ success, failure ]
+    image: 1and1internet/template-library-tools
+    volumes:
+      - /secrets:/secrets
+      - /var/run/docker.sock:/var/run/docker.sock
+    commands:
+      - make clean IMAGE_NAME=build-${CI_REPO#*/}-${CI_BUILD_NUMBER}/${CI_REPO#*/}
+

--- a/.lgtm
+++ b/.lgtm
@@ -1,1 +1,0 @@
-self_approval_off = true

--- a/Makefile
+++ b/Makefile
@@ -48,4 +48,7 @@ run-rspec:
 	## Testing image ${IMAGE_NAME}
 	IMAGE=${IMAGE_NAME} rspec ${RSPEC_ARGS}
 
-.PHONY: all pull build test do-test checkout-drone-tests run-rspec
+clean:
+	-docker rmi ${IMAGE_NAME}
+
+.PHONY: all pull build test do-test checkout-drone-tests run-rspec clean


### PR DESCRIPTION
- Clean up the build image on completion or failure to help avoid the storage becoming full

- Pull the rspec image early so that the test stage doesn't have to do it ... thereby making the time taken for testing comparable between runs